### PR TITLE
fix: ws→socket rename missed in already_connected node handler

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1076,14 +1076,14 @@ export function attachGatewayWsMessageHandler(params: {
               connId,
               existingConnId: registerResult.existingConnId,
             });
-            ws.send(
+            socket.send(
               JSON.stringify({
                 type: "error",
                 code: "already_connected",
                 message: "Node already connected from another instance",
               }),
             );
-            ws.close(4409, "already_connected");
+            socket.close(4409, "already_connected");
             return;
           }
           const nodeSession = registerResult;


### PR DESCRIPTION
The `already_connected` branch in the node handshake was still using `ws` after the parameter was renamed to `socket`, causing a runtime crash when a node tries to connect while already registered.

```ts
- ws.send(...) // ReferenceError: ws is not defined
- ws.close(...)
+ socket.send(...)
+ socket.close(...)
```