### PR TITLE
chore: gitignore work-specific skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,11 @@ package-lock.json
 .agent/
 skills-lock.json
 
+# Work-specific skills (corporate, not for public repo)
+skills/crp/
+skills/m365/
+skills/outlook/
+
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig
 


### PR DESCRIPTION
Adds `skills/crp/`, `skills/m365/`, and `skills/outlook/` to `.gitignore` to prevent corp-internal/work-specific skill directories from being accidentally committed to the public repo.